### PR TITLE
Ensure paramsub terminates or aborts

### DIFF
--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -227,7 +227,12 @@ func substituteParameters(layout *Layout, parameters map[string]string) (*Layout
 			return nil, fmt.Errorf("invalid parameter format")
 		}
 
-		replacementDirectives = append(replacementDirectives, fmt.Sprintf("{%s}", parameter))
+		parameterVar := fmt.Sprintf("{%s}", parameter)
+		if strings.Contains(value, parameterVar) {
+			return nil, fmt.Errorf("parameter's value refers to itself")
+		}
+
+		replacementDirectives = append(replacementDirectives, parameterVar)
 		replacementDirectives = append(replacementDirectives, value)
 	}
 


### PR DESCRIPTION
The verifier runs parameter substitution multiple times until the output string is the same as the input string. This allows for nested parameter substitution as seen in the current npm-sigstore example. However, the implementation lacked a check to ensure a parameter's value didn't refer to the same parameter.