### PR TITLE
Skip attestations that cannot be verified rather than abort

### DIFF
--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -59,7 +59,8 @@ func Verify(layout *Layout, attestations map[string]*dsse.Envelope, parameters m
 
 		acceptedKeys, err := envVerifier.Verify(context.Background(), env)
 		if err != nil {
-			return err
+			log.Infof("Unable to verify %s's signatures", attestationName)
+			continue
 		}
 
 		sb, err := env.DecodeB64Payload()

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -59,6 +59,18 @@ func Verify(layout *Layout, attestations map[string]*dsse.Envelope, parameters m
 
 		acceptedKeys, err := envVerifier.Verify(context.Background(), env)
 		if err != nil {
+			// The verifier loads all attestations and verifies their
+			// signatures. It represents their claims in the format "<signer>
+			// says <claim> for <step>", allowing policy to be written as "does
+			// one of <trusted signers> say <claim> for <step>?"
+			// While this might result in verifying the signatures of
+			// attestations that aren't required for the specific layout, it
+			// more cleanly separates policy evaluation from claim expression.
+			// Also, we do not authenticate attestations from unknown verifiers,
+			// as the keys used to verify the attestation signatures are taken
+			// from the layout.  If we encounter an attestation signed by an
+			// unrecognized key, the verifier logs this and moves on. This
+			// attestation is not considered for further verification.
 			log.Infof("Unable to verify %s's signatures", attestationName)
 			continue
 		}


### PR DESCRIPTION
If there are extra attestations signed by keys not in the policy, the verifier currently terminates with an error, even if the attestation isn't necessary for the layout. This PR makes the verifier ignore such claims, proceeding with verification of authenticated attestations.